### PR TITLE
issue/backports 20230102

### DIFF
--- a/deployment/src/main/java/org/neo4j/ogm/quarkus/deployment/EntitiesBuildItem.java
+++ b/deployment/src/main/java/org/neo4j/ogm/quarkus/deployment/EntitiesBuildItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deployment/src/main/java/org/neo4j/ogm/quarkus/deployment/Neo4jOgmDevConsoleProcessor.java
+++ b/deployment/src/main/java/org/neo4j/ogm/quarkus/deployment/Neo4jOgmDevConsoleProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deployment/src/main/java/org/neo4j/ogm/quarkus/deployment/Neo4jOgmProcessor.java
+++ b/deployment/src/main/java/org/neo4j/ogm/quarkus/deployment/Neo4jOgmProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deployment/src/main/java/org/neo4j/ogm/quarkus/deployment/Neo4jOgmSessionFactoryBuildItem.java
+++ b/deployment/src/main/java/org/neo4j/ogm/quarkus/deployment/Neo4jOgmSessionFactoryBuildItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deployment/src/test/java/org/neo4j/ogm/quarkus/test/ConfigurationTest.java
+++ b/deployment/src/test/java/org/neo4j/ogm/quarkus/test/ConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deployment/src/test/java/org/neo4j/ogm/quarkus/test/Neo4jOgmDevModeIT.java
+++ b/deployment/src/test/java/org/neo4j/ogm/quarkus/test/Neo4jOgmDevModeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deployment/src/test/java/org/neo4j/ogm/quarkus/test/Neo4jOgmTest.java
+++ b/deployment/src/test/java/org/neo4j/ogm/quarkus/test/Neo4jOgmTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deployment/src/test/java/org/neo4j/ogm/quarkus/test/domain/SomeClass.java
+++ b/deployment/src/test/java/org/neo4j/ogm/quarkus/test/domain/SomeClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/deployment/src/test/java/org/neo4j/ogm/quarkus/test/ignored/SomeOtherClass.java
+++ b/deployment/src/test/java/org/neo4j/ogm/quarkus/test/ignored/SomeOtherClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/etc/checkstyle/java-header.txt
+++ b/etc/checkstyle/java-header.txt
@@ -1,5 +1,5 @@
 ^\Q/*\E$
-^\Q * Copyright \E2022\Q the original author or authors.\E$
+^\Q * Copyright \E2022\-20\d\d\Q the original author or authors.\E$
 ^\Q *\E$
 ^\Q * Licensed under the Apache License, Version 2.0 (the "License");\E$
 ^\Q * you may not use this file except in compliance with the License.\E$

--- a/integration-tests/src/main/java/org/neo4j/ogm/quarkus/it/movies/Actor.java
+++ b/integration-tests/src/main/java/org/neo4j/ogm/quarkus/it/movies/Actor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/main/java/org/neo4j/ogm/quarkus/it/movies/Movie.java
+++ b/integration-tests/src/main/java/org/neo4j/ogm/quarkus/it/movies/Movie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/main/java/org/neo4j/ogm/quarkus/it/movies/MovieRepository.java
+++ b/integration-tests/src/main/java/org/neo4j/ogm/quarkus/it/movies/MovieRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/main/java/org/neo4j/ogm/quarkus/it/movies/MovieResource.java
+++ b/integration-tests/src/main/java/org/neo4j/ogm/quarkus/it/movies/MovieResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/main/java/org/neo4j/ogm/quarkus/it/movies/PeopleRepository.java
+++ b/integration-tests/src/main/java/org/neo4j/ogm/quarkus/it/movies/PeopleRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/main/java/org/neo4j/ogm/quarkus/it/movies/PeopleResource.java
+++ b/integration-tests/src/main/java/org/neo4j/ogm/quarkus/it/movies/PeopleResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/main/java/org/neo4j/ogm/quarkus/it/movies/Person.java
+++ b/integration-tests/src/main/java/org/neo4j/ogm/quarkus/it/movies/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/org/neo4j/ogm/quarkus/it/NativeNeo4jOgmResourceIT.java
+++ b/integration-tests/src/test/java/org/neo4j/ogm/quarkus/it/NativeNeo4jOgmResourceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-tests/src/test/java/org/neo4j/ogm/quarkus/it/Neo4jOgmResourcesIT.java
+++ b/integration-tests/src/test/java/org/neo4j/ogm/quarkus/it/Neo4jOgmResourcesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
 					<plugin>
 						<groupId>org.jreleaser</groupId>
 						<artifactId>jreleaser-maven-plugin</artifactId>
-						<version>1.3.1</version>
+						<version>1.4.0</version>
 						<inherited>false</inherited>
 						<configuration>
 							<jreleaser>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
 		<maven.compiler.release>${java.version}</maven.compiler.release>
 		<maven.version>3.8.6</maven.version>
 		<neo4j-java-driver.version>4.4.11</neo4j-java-driver.version>
-		<neo4j-migrations.version>1.14.0</neo4j-migrations.version>
+		<neo4j-migrations.version>1.15.2</neo4j-migrations.version>
 		<neo4j-ogm.version>3.2.38</neo4j-ogm.version>
 		<neo4j.image>neo4j:4.4</neo4j.image>
 		<nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 
 	<properties>
 		<checkstyle.version>10.5.0</checkstyle.version>
-		<docker-maven-plugin.version>0.40.2</docker-maven-plugin.version>
+		<docker-maven-plugin.version>0.40.3</docker-maven-plugin.version>
 		<exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
 		<java-module-name />
 		<java.version>11</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 	</scm>
 
 	<properties>
-		<checkstyle.version>10.5.0</checkstyle.version>
+		<checkstyle.version>10.6.0</checkstyle.version>
 		<docker-maven-plugin.version>0.40.3</docker-maven-plugin.version>
 		<exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
 		<java-module-name />

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 		<maven.compiler.parameters>true</maven.compiler.parameters>
 		<maven.compiler.release>${java.version}</maven.compiler.release>
 		<maven.version>3.8.6</maven.version>
-		<neo4j-java-driver.version>4.4.9</neo4j-java-driver.version>
+		<neo4j-java-driver.version>4.4.11</neo4j-java-driver.version>
 		<neo4j-migrations.version>1.14.0</neo4j-migrations.version>
 		<neo4j-ogm.version>3.2.38</neo4j-ogm.version>
 		<neo4j.image>neo4j:4.4</neo4j.image>

--- a/runtime/src/main/java/org/neo4j/ogm/quarkus/runtime/EntitiesSupplier.java
+++ b/runtime/src/main/java/org/neo4j/ogm/quarkus/runtime/EntitiesSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/src/main/java/org/neo4j/ogm/quarkus/runtime/Neo4jOgmBuiltTimeProperties.java
+++ b/runtime/src/main/java/org/neo4j/ogm/quarkus/runtime/Neo4jOgmBuiltTimeProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/src/main/java/org/neo4j/ogm/quarkus/runtime/Neo4jOgmDevConsoleRecorder.java
+++ b/runtime/src/main/java/org/neo4j/ogm/quarkus/runtime/Neo4jOgmDevConsoleRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/src/main/java/org/neo4j/ogm/quarkus/runtime/Neo4jOgmProperties.java
+++ b/runtime/src/main/java/org/neo4j/ogm/quarkus/runtime/Neo4jOgmProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/src/main/java/org/neo4j/ogm/quarkus/runtime/Neo4jOgmRecorder.java
+++ b/runtime/src/main/java/org/neo4j/ogm/quarkus/runtime/Neo4jOgmRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
- build(deps): Bump docker-maven-plugin from 0.40.2 to 0.40.3 (#118)
- build(deps): Bump jreleaser-maven-plugin from 1.3.1 to 1.4.0 (#123)
- build(deps): Bump neo4j-java-driver from 4.4.9 to 4.4.11
- build(deps): Bump checkstyle from 10.5.0 to 10.6.0 (#124)
- build(deps): Bump neo4j-migrations-quarkus from 1.14.0 to 1.15.2
- chore: Extend license header to 2023.
